### PR TITLE
board: acrn : config for the flash runner

### DIFF
--- a/boards/x86/acrn/board.cmake
+++ b/boards/x86/acrn/board.cmake
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
+
+board_set_flasher_ifnset(misc-flasher)
+board_finalize_runner_args(misc-flasher)


### PR DESCRIPTION
Add config for acrn using sanitycheck automation.
For zephyr ACRN visualization testing, we need to add this file. 

Signed-off-by: Enjiax Mai <enjiax.mai@intel.com>